### PR TITLE
Implement radio settings menu

### DIFF
--- a/src/apps/set_radio.cpp
+++ b/src/apps/set_radio.cpp
@@ -6,7 +6,7 @@
 
 #include "printf.h"
 #include "apps.h"
-#include "set_vfo.h" // Included for potential navigation, though set_radio.h might be more direct
+#include "set_vfo.h" // Included for potential navigation
 #include "system.h"
 #include "ui.h"
 #include "u8g2.h"
@@ -34,7 +34,11 @@ void SetRadio::drawScreen(void) {
     ui.setBlackColor(); // Ensure color is set for the menu list items
 
     // Draw the radio settings list items starting at Y position 15
-    menulist.draw(15);
+    menulist.draw(15, getCurrentOption());
+
+    if (optionSelected != 0) {
+        optionlist.drawPopup(ui, true);
+    }
 
     ui.updateDisplay(); // Send the buffer to the physical display
 }
@@ -68,6 +72,101 @@ void SetRadio::timeout(void) {
     systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::MainVFO);
 };
 
+const char* SetRadio::getCurrentOption() {
+    switch (menulist.getListPos() + 1) {
+    case 1:
+        return ui.getStrValue(Settings::MicDBStr, (uint8_t)settings.radioSettings.micDB - 1);
+    case 2:
+        return ui.getStrValue(Settings::onoffStr, (uint8_t)settings.radioSettings.batterySave);
+    case 3:
+        return ui.getStrValue(Settings::onoffStr, (uint8_t)settings.radioSettings.busyLockout);
+    case 4:
+        return ui.getStrValue(Settings::BacklightLevelStr, settings.radioSettings.backlightLevel);
+    case 5:
+        return ui.getStrValue(Settings::BacklightTimeStr, (uint8_t)settings.radioSettings.backlightTime);
+    case 6:
+        return ui.getStrValue(Settings::BacklightModeStr, (uint8_t)settings.radioSettings.backlightMode);
+    case 7:
+        return ui.getStrValue(Settings::LCDContrastStr, settings.radioSettings.lcdContrast);
+    case 8:
+        return ui.getStrValue(Settings::TXTimeoutStr, (uint8_t)settings.radioSettings.txTOT);
+    case 9:
+        return ui.getStrValue(Settings::onoffStr, (uint8_t)settings.radioSettings.beep);
+    default:
+        return NULL;
+    }
+}
+
+void SetRadio::loadOptions() {
+    switch (optionSelected) {
+    case 1:
+        optionlist.set((uint8_t)settings.radioSettings.micDB - 1, 5, 0, Settings::MicDBStr);
+        break;
+    case 2:
+        optionlist.set((uint8_t)settings.radioSettings.batterySave, 5, 0, Settings::onoffStr);
+        break;
+    case 3:
+        optionlist.set((uint8_t)settings.radioSettings.busyLockout, 5, 0, Settings::onoffStr);
+        break;
+    case 4:
+        optionlist.set(settings.radioSettings.backlightLevel, 5, 0, Settings::BacklightLevelStr);
+        break;
+    case 5:
+        optionlist.set((uint8_t)settings.radioSettings.backlightTime, 5, 0, Settings::BacklightTimeStr);
+        break;
+    case 6:
+        optionlist.set((uint8_t)settings.radioSettings.backlightMode, 5, 0, Settings::BacklightModeStr);
+        break;
+    case 7:
+        optionlist.set(settings.radioSettings.lcdContrast, 5, 0, Settings::LCDContrastStr);
+        break;
+    case 8:
+        optionlist.set((uint8_t)settings.radioSettings.txTOT, 5, 0, Settings::TXTimeoutStr);
+        break;
+    case 9:
+        optionlist.set((uint8_t)settings.radioSettings.beep, 5, 0, Settings::onoffStr);
+        break;
+    default:
+        optionSelected = 0;
+        break;
+    }
+}
+
+void SetRadio::setOptions() {
+    uint8_t sel = optionlist.getListPos();
+    switch (optionSelected) {
+    case 1:
+        settings.radioSettings.micDB = (Settings::MicDB)(sel + 1);
+        break;
+    case 2:
+        settings.radioSettings.batterySave = (Settings::ONOFF)sel;
+        break;
+    case 3:
+        settings.radioSettings.busyLockout = (Settings::ONOFF)sel;
+        break;
+    case 4:
+        settings.radioSettings.backlightLevel = sel;
+        break;
+    case 5:
+        settings.radioSettings.backlightTime = (Settings::BacklightTime)sel;
+        break;
+    case 6:
+        settings.radioSettings.backlightMode = (Settings::BacklightMode)sel;
+        break;
+    case 7:
+        settings.radioSettings.lcdContrast = sel;
+        break;
+    case 8:
+        settings.radioSettings.txTOT = (Settings::TXTimeout)sel;
+        break;
+    case 9:
+        settings.radioSettings.beep = (Settings::ONOFF)sel;
+        break;
+    default:
+        break;
+    }
+}
+
 /**
  * @brief Handles keyboard input for the SetRadio application.
  * This function processes key presses for navigating the settings list,
@@ -75,59 +174,38 @@ void SetRadio::timeout(void) {
  * @param keyCode The code of the key that was pressed or released.
  * @param keyState The state of the key (e.g., KEY_PRESSED, KEY_LONG_PRESSED_CONT).
  */
-void SetRadio::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {    
-    // Process key presses or continuous long presses
-    if (keyState == Keyboard::KeyState::KEY_PRESSED || keyState == Keyboard::KeyState::KEY_LONG_PRESSED_CONT) {
-        if (keyCode == Keyboard::KeyCode::KEY_UP) {
-            menulist.prev(); // Navigate to the previous setting
-        } else if (keyCode == Keyboard::KeyCode::KEY_DOWN) {
-            menulist.next(); // Navigate to the next setting
-        } else if (keyCode == Keyboard::KeyCode::KEY_EXIT) {
-            // Exit the radio settings menu and return to the main VFO screen
-            systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::MainVFO);
-        }
-
-        // Handle selection of a setting item
-        if (keyCode == Keyboard::KeyCode::KEY_MENU) {
-            switch (menulist.getListPos()) {
-                // TODO: Implement actions for each radio setting.
-                // This will likely involve:
-                // 1. Storing the current setting's index or a unique ID.
-                // 2. Loading a sub-screen or a value editor for the selected setting.
-                // 3. For settings with predefined options (e.g., BATT SAVE), it might involve
-                //    cycling through options directly or using a popup.
-                // 4. For numerical values (e.g., MIC DB, LCD CONTRAST), it might involve
-                //    incrementing/decrementing values or direct number input.
-                
-                case 0: // MIC DB
-                    // Example: Load a value editor for MIC DB
-                    break;
-                case 1: // BATT SAVE
-                    // Example: Cycle through BATT SAVE options or load a selection list
-                    break;
-                case 2: // BUSY LOCKOUT
-                    break;
-                case 3: // BCKLIGHT LEVEL
-                    break;
-                case 4: // BCKLIGHT TIME
-                    break;
-                case 5: // BCKLIGHT MODE
-                    break;
-                case 6: // LCD CONTRAST
-                    break;
-                case 7: // TX TOT (Transmit Time-Out Timer)
-                    break;
-                case 8: // BEEP
-                    break;
-                case 9: // RESET
-                    // Load the EEPROM reset application
+void SetRadio::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
+    if (optionSelected == 0) {
+        if (keyState == Keyboard::KeyState::KEY_PRESSED || keyState == Keyboard::KeyState::KEY_LONG_PRESSED_CONT) {
+            if (keyCode == Keyboard::KeyCode::KEY_UP) {
+                menulist.prev();
+            } else if (keyCode == Keyboard::KeyCode::KEY_DOWN) {
+                menulist.next();
+            } else if (keyCode == Keyboard::KeyCode::KEY_EXIT) {
+                systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::MainVFO);
+            } else if (keyCode == Keyboard::KeyCode::KEY_MENU) {
+                uint8_t idx = menulist.getListPos() + 1;
+                if (idx == 10) {
                     systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::RESETEEPROM);
-                    break;
-
-                default:
-                    // Should not happen if menu items and cases are synchronized
-                    break;
+                } else {
+                    optionSelected = idx;
+                    optionlist.setPopupTitle(menulist.getStringLine());
+                    loadOptions();
+                }
             }
-        } 
+        }
+    } else {
+        if (keyState == Keyboard::KeyState::KEY_PRESSED) {
+            if (keyCode == Keyboard::KeyCode::KEY_UP) {
+                optionlist.prev();
+            } else if (keyCode == Keyboard::KeyCode::KEY_DOWN) {
+                optionlist.next();
+            } else if (keyCode == Keyboard::KeyCode::KEY_EXIT) {
+                optionSelected = 0;
+            } else if (keyCode == Keyboard::KeyCode::KEY_MENU) {
+                setOptions();
+                optionSelected = 0;
+            }
+        }
     }
 }

--- a/src/apps/set_radio.h
+++ b/src/apps/set_radio.h
@@ -5,6 +5,7 @@
 
 #include "apps.h"
 #include "radio.h" // May not be directly needed here, but often radio settings affect the Radio class
+#include "settings.h"
 #include "ui.h"
 
 namespace Applications
@@ -21,8 +22,8 @@ namespace Applications
          * @param systask Reference to the main SystemTask for system-level operations.
          * @param ui Reference to the UI object for display rendering.
          */
-        SetRadio(System::SystemTask& systask, UI& ui)
-            : Application(systask, ui), menulist(ui) { // Initialize base class and menulist member
+        SetRadio(System::SystemTask& systask, UI& ui, Settings& settings)
+            : Application(systask, ui), menulist(ui), optionlist(ui), settings{ settings } {
         }
 
         /**
@@ -57,8 +58,16 @@ namespace Applications
         void action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState);
 
     private:
-        SelectionList menulist; // UI element for displaying and managing the list of radio settings.
-                                // Each item in this list will correspond to a radio parameter.
+        SelectionList menulist;        // Main list of radio settings
+        SelectionListPopup optionlist; // Popup for selecting option values
+
+        Settings& settings;            // Reference to global settings
+
+        uint8_t optionSelected = 0;    // Currently active option index (0 when none)
+
+        void loadOptions();            // Populate optionlist for selected item
+        void setOptions();             // Save selected option back to settings
+        const char* getCurrentOption();// Return string for current value
     };
 
 } // namespace Applications

--- a/src/system/settings.h
+++ b/src/system/settings.h
@@ -56,6 +56,8 @@ public:
     static constexpr const char* BacklightTimeStr = "OFF\nON\n5s\n10s\n15s\n20s\n30s\n1m\n2m\n4m"; ///< Backlight auto-off timer options.
     static constexpr const char* MicDBStr = "+1.1dB\n+4.0dB\n+8.0dB\n+12.0dB\n+15.1dB"; ///< Microphone gain options.
     static constexpr const char* BacklightModeStr = "OFF\nTX\nRX\nTX/RX"; ///< Backlight activation mode options.
+    static constexpr const char* BacklightLevelStr = "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10"; ///< Backlight brightness levels.
+    static constexpr const char* LCDContrastStr = "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15"; ///< LCD contrast options.
 
     // --- CTCSS and DCS code tables ---
     /// Standard CTCSS tone frequencies in 0.1 Hz units (e.g., 670 for 67.0 Hz).

--- a/src/system/system.h
+++ b/src/system/system.h
@@ -81,7 +81,7 @@ namespace System
             menuApp(*this, ui), // Initialize menu application
             setVFOAApp(*this, ui, Settings::VFOAB::VFOA, settings, radio), // Initialize Set VFO A application
             setVFOBApp(*this, ui, Settings::VFOAB::VFOB, settings, radio), // Initialize Set VFO B application
-            setRadioApp(*this, ui) // Initialize Set Radio application
+            setRadioApp(*this, ui, settings) // Initialize Set Radio application
         {
             initSystem(); // Perform initial system setup
         }


### PR DESCRIPTION
## Summary
- add lists for backlight level and LCD contrast
- implement configurable radio settings menu
- connect menu with Settings storage
- pass Settings to SetRadio at SystemTask construction

## Testing
- `make` *(fails: CRCMOD not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68447656840083328de01c43726b0607