### PR TITLE
Add delayed EEPROM save for radio settings

### DIFF
--- a/src/system/settings.h
+++ b/src/system/settings.h
@@ -293,10 +293,25 @@ public:
     }
 
     void saveRadioSettings() {
-        /*if (hasDataToSave) {
-            eeprom.writeBuffer(0x0000, &radioSettings, sizeof(SETTINGS));
-            hasDataToSave = false;
-        }*/
+        eeprom.writeBuffer(0x0000, &radioSettings, sizeof(SETTINGS));
+    }
+
+    void requestSaveRadioSettings() {
+        radioSavePending = true;
+        radioSaveDelay = saveDelayTicks;
+    }
+
+    void handleSaveTimers() {
+        if (radioSavePending) {
+            if (radioSaveDelay > 0) {
+                --radioSaveDelay;
+            } else {
+                saveRadioSettings();
+                radioSavePending = false;
+            }
+        }
+
+        // TODO: implement channel memory save handling when needed
     }
 
     void loadRadioSettings() {
@@ -321,6 +336,13 @@ private:
     uint16_t initBlock = 0x0000;
     static constexpr uint16_t maxBlock = 0x000F;
 
-    bool hasDataToSave = false;
+    static constexpr uint8_t saveDelaySeconds = 5;
+    static constexpr uint8_t saveDelayTicks = saveDelaySeconds * 2; // half-second ticks
+
+    bool radioSavePending = false;
+    uint8_t radioSaveDelay = 0;
+
+    bool memorySavePending = false;        // Placeholder for channel memory save
+    uint8_t memorySaveDelay = 0;           // Placeholder counter
 
 };

--- a/src/system/system.cpp
+++ b/src/system/system.cpp
@@ -224,7 +224,8 @@ void SystemTask::processSystemNotification(SystemMessages notification) {
         }
         break;
     }
-    case SystemMSG::MSG_SAVESETTINGS: 
+    case SystemMSG::MSG_SAVESETTINGS:
+        settings.requestSaveRadioSettings();
         break;
     
     case SystemMSG::MSG_APP_LOAD:
@@ -270,6 +271,8 @@ void SystemTask::runTimerImpl(void) {
             timeoutLightCount++;
         }
     }
+
+    settings.handleSaveTimers();
 }
 
 void SystemTask::appTimerImpl(void) {


### PR DESCRIPTION
## Summary
- handle MSG_SAVESETTINGS by queuing a delayed EEPROM write
- add timer based saving logic to Settings
- call saving logic from periodic timer

## Testing
- `make` *(fails: powershell not found)*

------
https://chatgpt.com/codex/tasks/task_e_684565f4166c83328961a03830073888