### PR TITLE
Implement applyRadioSettings

### DIFF
--- a/src/system/settings.h
+++ b/src/system/settings.h
@@ -319,7 +319,43 @@ public:
     }
 
     void applyRadioSettings() {
-        
+        // Apply backlight timeout based on stored setting
+        uint16_t timeout = 0;
+        switch (radioSettings.backlightTime) {
+        default:
+        case BacklightTime::BACKLIGHT_OFF:
+            timeout = 0;
+            break;
+        case BacklightTime::BACKLIGHT_ON:
+            timeout = 0xFFFF; // effectively disable timeout
+            break;
+        case BacklightTime::BACKLIGHT_5S:
+            timeout = 5;
+            break;
+        case BacklightTime::BACKLIGHT_10S:
+            timeout = 10;
+            break;
+        case BacklightTime::BACKLIGHT_15S:
+            timeout = 15;
+            break;
+        case BacklightTime::BACKLIGHT_20S:
+            timeout = 20;
+            break;
+        case BacklightTime::BACKLIGHT_30S:
+            timeout = 30;
+            break;
+        case BacklightTime::BACKLIGHT_60S:
+            timeout = 60;
+            break;
+        case BacklightTime::BACKLIGHT_120S:
+            timeout = 120;
+            break;
+        case BacklightTime::BACKLIGHT_240S:
+            timeout = 240;
+            break;
+        }
+        systask.setBacklightTimeout(timeout);
+        systask.setLCDContrast(radioSettings.lcdContrast);
     }
 
     EEPROM& getEEPROM() {

--- a/src/system/system.cpp
+++ b/src/system/system.cpp
@@ -347,5 +347,13 @@ void SystemTask::loadApplication(Applications::Applications app) {
     //taskEXIT_CRITICAL();
 }
 
+void SystemTask::setLCDContrast(uint8_t contrast) {
+    st7565.setContrast(contrast);
+}
+
+void SystemTask::setBacklightTimeout(uint16_t seconds) {
+    backlightTimeout = seconds;
+}
+
 
 

--- a/src/system/system.h
+++ b/src/system/system.h
@@ -79,7 +79,14 @@ namespace System
 
         Battery getBattery() { return battery; }
 
-        void playBeep(Settings::BEEPType beep) { radio.playBeep(beep); }
+        void playBeep(Settings::BEEPType beep) {
+            if (settings.radioSettings.beep == Settings::ONOFF::ON) {
+                radio.playBeep(beep);
+            }
+        }
+
+        void setLCDContrast(uint8_t contrast);
+        void setBacklightTimeout(uint16_t seconds);
 
         // Static methods (required by FreeRTOS)
         static void runStatusTask(void* pvParameters);


### PR DESCRIPTION
## Summary
- implement radio settings application
- respect beep setting when playing sounds
- expose methods to update LCD contrast and backlight timeout

## Testing
- `make` *(fails: crcmod missing and other build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68456cd1587483328bfadec56e7813cd