### PR TITLE
Persist changes only when modified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ifeq ($(OS), Windows_NT) # windows
 	# Detect if PowerShell is available for directory listing	
 	PS_EXISTS := $(shell $(WHERE) powershell 2>$(DEV_NULL))	
 else
-	MKDIR = mkdir -p $(1)
+       MKDIR = mkdir -p
 	RM = rm -rf
 	FixPath = $1
     WHERE = which
@@ -215,8 +215,8 @@ all: directories app
 
 # Create necessary directories
 directories:
-	@if not exist $(BUILD) $(MKDIR) $(BUILD)
-	@if not exist $(BIN) $(MKDIR) $(BIN)
+	@$(MKDIR) $(BUILD)
+	@$(MKDIR) $(BIN)
 
 #------------------------------------------------------------------------------
 
@@ -226,18 +226,18 @@ OBJECTS = $(ASM_OBJS) $(FREERTOS_OBJS) $(CMSIS_OBJS) $(PRINTF_OBJS) $(U8G2_OBJS)
 
 $(BUILD)/%.o: %.c
 	@echo CC $<
-	@if not exist $(@D) $(MKDIR) $(@D)
+	@$(MKDIR) $(@D)
 	@$(CC) $(CCFLAGS) $(INC_PATHS) -c $< -o $@
 
 $(BUILD)/%.o: %.cpp
 	@echo GCC $<
-	@if not exist $(@D) $(MKDIR) $(@D)
+	@$(MKDIR) $(@D)
 	@$(CXX) $(CXXFLAGS) $(INC_PATHS) -c $< -o $@
 
 # Assemble files
 $(BUILD)/%.o: %.S
 	@echo AS $<
-	@if not exist $(@D) $(MKDIR) $(@D)
+	@$(MKDIR) $(@D)
 	@$(CXX) -x assembler-with-cpp $(ASMFLAGS) $(INC_PATHS) -c $< -o $@
 #------------------------------------------------------------------------------
 

--- a/src/apps/main_vfo.cpp
+++ b/src/apps/main_vfo.cpp
@@ -210,6 +210,8 @@ void MainVFO::savePopupValue(void) {
 
     radio.setVFO(radio.getCurrentVFO(), vfo);
     radio.setupToVFO(radio.getCurrentVFO());
+    systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
+    systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
 }
 
 void MainVFO::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
@@ -246,6 +248,8 @@ void MainVFO::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
 
                 radio.setVFO(radio.getCurrentVFO(), vfo);
                 radio.setupToVFO(radio.getCurrentVFO());
+                systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
+                systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
             }
             else if (keyCode == Keyboard::KeyCode::KEY_DOWN) {
                 uint32_t newFrequency = vfo.rx.frequency - Settings::StepFrequencyTable[(uint8_t)vfo.step];
@@ -253,6 +257,8 @@ void MainVFO::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
 
                 radio.setVFO(radio.getCurrentVFO(), vfo);
                 radio.setupToVFO(radio.getCurrentVFO());
+                systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
+                systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
             }
             else if (keyCode == Keyboard::KeyCode::KEY_MENU) {
                 if (showFreqInput) {
@@ -261,6 +267,8 @@ void MainVFO::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
                     vfo.tx.frequency = (uint32_t)(freqInput & 0x7FFFFFF);
                     radio.setVFO(radio.getCurrentVFO(), vfo);
                     radio.setupToVFO(radio.getCurrentVFO());
+                    systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
+                    systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
                 }
                 else {
                     systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::Menu);

--- a/src/apps/set_radio.cpp
+++ b/src/apps/set_radio.cpp
@@ -4,6 +4,7 @@
 #include "system.h"
 #include "ui.h"
 #include "u8g2.h"
+#include <cstring>
 
 using namespace Applications;
 
@@ -34,6 +35,7 @@ void SetRadio::drawScreen(void) {
 
 void SetRadio::init(void) {
     menulist.set(0, 6, 127, "MIC DB\nBATT SAVE\nBUSY LOCKOUT\nBLIGHT LEVEL\nBLIGHT TIME\nBLIGHT MODE\nLCD CONTRAST\nTX TOT\nBEEP\nRESET");
+    initialSettings = settings.radioSettings; // snapshot original values
 }
 
 void SetRadio::update(void) {
@@ -41,6 +43,10 @@ void SetRadio::update(void) {
 }
 
 void SetRadio::timeout(void) {
+    if (memcmp(&initialSettings, &settings.radioSettings, sizeof(Settings::SETTINGS)) != 0) {
+        systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
+        initialSettings = settings.radioSettings;
+    }
     systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::MainVFO);
 };
 
@@ -154,7 +160,11 @@ void SetRadio::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
                 menulist.prev();
             } else if (keyCode == Keyboard::KeyCode::KEY_DOWN) {
                 menulist.next();
-            } else if (keyCode == Keyboard::KeyCode::KEY_EXIT) {                
+            } else if (keyCode == Keyboard::KeyCode::KEY_EXIT) {
+                if (memcmp(&initialSettings, &settings.radioSettings, sizeof(Settings::SETTINGS)) != 0) {
+                    systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
+                    initialSettings = settings.radioSettings;
+                }
                 systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::MainVFO);
             } else if (keyCode == Keyboard::KeyCode::KEY_MENU) {
                 inputSelect = 0; // reset direct input

--- a/src/apps/set_radio.h
+++ b/src/apps/set_radio.h
@@ -30,6 +30,7 @@ namespace Applications
         SelectionListPopup optionlist; // Popup for selecting option values
 
         Settings& settings;            // Reference to global settings
+        Settings::SETTINGS initialSettings; // Original settings snapshot
 
         uint8_t inputSelect = 0;       // Accumulates digits for direct menu selection
         uint8_t optionSelected = 0;    // Currently active option index (0 when none)

--- a/src/apps/set_vfo.cpp
+++ b/src/apps/set_vfo.cpp
@@ -4,6 +4,7 @@
 #include "system.h"
 #include "ui.h"
 #include "u8g2.h"
+#include <cstring>
 
 using namespace Applications;
 
@@ -71,6 +72,7 @@ void SetVFO::drawScreen(void) {
 void SetVFO::init(void) {
     menulist.set(0, 6, 127, "SQUELCH\nSTEP\nMODE\nBANDWIDTH\nTX POWER\nSHIFT\nOFFSET\nRX CODE TYPE\nRX CODE\nTX CODE TYPE\nTX CODE\nTX STE\nRX STE\nCOMPANDER\nRX ACG\nPTT ID\nROGER");
     vfo = radio.getVFO(vfoab);
+    initialVFO = vfo; // keep original values for change detection
 }
 
 void SetVFO::update(void) {
@@ -79,6 +81,11 @@ void SetVFO::update(void) {
 
 void SetVFO::timeout(void) {
     if (optionSelected == 0 && userOptionSelected == 0) {
+        if (memcmp(&initialVFO, &vfo, sizeof(Settings::VFO)) != 0) {
+            settings.radioSettings.vfo[(uint8_t)vfoab] = vfo;
+            systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
+            initialVFO = vfo;
+        }
         systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::MainVFO);
     }
     else {
@@ -280,7 +287,11 @@ void SetVFO::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
                 break;
             case Keyboard::KeyCode::KEY_EXIT:
                 if (keyState == Keyboard::KeyState::KEY_PRESSED) {
-                    // TODO : save ???
+                    if (memcmp(&initialVFO, &vfo, sizeof(Settings::VFO)) != 0) {
+                        settings.radioSettings.vfo[(uint8_t)vfoab] = vfo;
+                        systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
+                        initialVFO = vfo;
+                    }
                     systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::MainVFO);
                 }
                 break;
@@ -336,11 +347,15 @@ void SetVFO::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
                 break;
             case Keyboard::KeyCode::KEY_MENU:
                 if (keyState == Keyboard::KeyState::KEY_PRESSED) {
+                    Settings::VFO before = vfo;
                     setOptions();
                     radio.setVFO(vfoab, vfo);
                     optionSelected = 0;
                     userOptionSelected = 0;
-                    systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
+                    if (memcmp(&before, &vfo, sizeof(Settings::VFO)) != 0) {
+                        settings.radioSettings.vfo[(uint8_t)vfoab] = vfo;
+                        initialVFO = vfo;
+                    }
                 }
                 break;
             default:

--- a/src/apps/set_vfo.h
+++ b/src/apps/set_vfo.h
@@ -29,6 +29,7 @@ namespace Applications
         RadioNS::Radio& radio;
 
         Settings::VFO vfo;
+        Settings::VFO initialVFO; // store original VFO settings for change detection
 
         uint8_t inputSelect = 0;
         uint8_t optionSelected = 0;


### PR DESCRIPTION
## Summary
- save settings only when VFO or Radio options actually change
- persist VFO changes from Main VFO actions
- track original values for change detection
- fix Makefile directory creation commands

## Testing
- `make -k` *(fails: "arm-none-eabi-gcc: No such file or directory")*

------
https://chatgpt.com/codex/tasks/task_e_68457db72da08332b4a1175a9cc712d3