### PR TITLE
Centralize settings change checks

### DIFF
--- a/src/apps/main_vfo.cpp
+++ b/src/apps/main_vfo.cpp
@@ -4,7 +4,6 @@
 #include "system.h"
 #include "ui.h"
 #include "u8g2.h"
-#include <cstring>
 
 using namespace Applications;
 
@@ -198,7 +197,6 @@ void MainVFO::timeout(void) {
 
 void MainVFO::savePopupValue(void) {
     Settings::VFO vfo = radio.getActiveVFO();
-    Settings::VFO before = vfo;
 
     if (popupSelected == BANDWIDTH) {
         vfo.bw = (BK4819_Filter_Bandwidth)popupList.getListPos();
@@ -210,14 +208,10 @@ void MainVFO::savePopupValue(void) {
         vfo.power = (Settings::TXOutputPower)popupList.getListPos();
     }
 
-    bool changed = memcmp(&before, &vfo, sizeof(Settings::VFO)) != 0;
-
     radio.setVFO(radio.getCurrentVFO(), vfo);
     radio.setupToVFO(radio.getCurrentVFO());
-    if (changed) {
-        systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
-        systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
-    }
+    systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
+    systask.getSettings().scheduleSaveIfNeeded();
 }
 
 void MainVFO::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
@@ -249,46 +243,32 @@ void MainVFO::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
         else {
 
             if (keyCode == Keyboard::KeyCode::KEY_UP) {
-                Settings::VFO before = vfo;
                 uint32_t newFrequency = vfo.rx.frequency + Settings::StepFrequencyTable[(uint8_t)vfo.step];
                 vfo.rx.frequency = (uint32_t)(newFrequency & 0x07FFFFFF);
 
-                bool changed = memcmp(&before, &vfo, sizeof(Settings::VFO)) != 0;
-
                 radio.setVFO(radio.getCurrentVFO(), vfo);
                 radio.setupToVFO(radio.getCurrentVFO());
-                if (changed) {
-                    systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
-                    systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
-                }
+                systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
+                systask.getSettings().scheduleSaveIfNeeded();
             }
             else if (keyCode == Keyboard::KeyCode::KEY_DOWN) {
-                Settings::VFO before = vfo;
                 uint32_t newFrequency = vfo.rx.frequency - Settings::StepFrequencyTable[(uint8_t)vfo.step];
                 vfo.rx.frequency = (uint32_t)(newFrequency & 0x7FFFFFF);
 
-                bool changed = memcmp(&before, &vfo, sizeof(Settings::VFO)) != 0;
-
                 radio.setVFO(radio.getCurrentVFO(), vfo);
                 radio.setupToVFO(radio.getCurrentVFO());
-                if (changed) {
-                    systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
-                    systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
-                }
+                systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
+                systask.getSettings().scheduleSaveIfNeeded();
             }
             else if (keyCode == Keyboard::KeyCode::KEY_MENU) {
                 if (showFreqInput) {
                     showFreqInput = false;
-                    Settings::VFO before = vfo;
                     vfo.rx.frequency = (uint32_t)(freqInput & 0x7FFFFFF);
                     vfo.tx.frequency = (uint32_t)(freqInput & 0x7FFFFFF);
-                    bool changed = memcmp(&before, &vfo, sizeof(Settings::VFO)) != 0;
                     radio.setVFO(radio.getCurrentVFO(), vfo);
                     radio.setupToVFO(radio.getCurrentVFO());
-                    if (changed) {
-                        systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
-                        systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
-                    }
+                    systask.getSettings().radioSettings.vfo[(uint8_t)radio.getCurrentVFO()] = vfo;
+                    systask.getSettings().scheduleSaveIfNeeded();
                 }
                 else {
                     systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::Menu);

--- a/src/apps/set_radio.cpp
+++ b/src/apps/set_radio.cpp
@@ -4,7 +4,6 @@
 #include "system.h"
 #include "ui.h"
 #include "u8g2.h"
-#include <cstring>
 
 using namespace Applications;
 
@@ -35,7 +34,6 @@ void SetRadio::drawScreen(void) {
 
 void SetRadio::init(void) {
     menulist.set(0, 6, 127, "MIC DB\nBATT SAVE\nBUSY LOCKOUT\nBLIGHT LEVEL\nBLIGHT TIME\nBLIGHT MODE\nLCD CONTRAST\nTX TOT\nBEEP\nRESET");
-    initialSettings = settings.radioSettings; // snapshot original values
 }
 
 void SetRadio::update(void) {
@@ -43,10 +41,7 @@ void SetRadio::update(void) {
 }
 
 void SetRadio::timeout(void) {
-    if (memcmp(&initialSettings, &settings.radioSettings, sizeof(Settings::SETTINGS)) != 0) {
-        systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
-        initialSettings = settings.radioSettings;
-    }
+    settings.scheduleSaveIfNeeded();
     systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::MainVFO);
 };
 
@@ -161,10 +156,7 @@ void SetRadio::action(Keyboard::KeyCode keyCode, Keyboard::KeyState keyState) {
             } else if (keyCode == Keyboard::KeyCode::KEY_DOWN) {
                 menulist.next();
             } else if (keyCode == Keyboard::KeyCode::KEY_EXIT) {
-                if (memcmp(&initialSettings, &settings.radioSettings, sizeof(Settings::SETTINGS)) != 0) {
-                    systask.pushMessage(System::SystemTask::SystemMSG::MSG_SAVESETTINGS, 0);
-                    initialSettings = settings.radioSettings;
-                }
+                settings.scheduleSaveIfNeeded();
                 systask.pushMessage(System::SystemTask::SystemMSG::MSG_APP_LOAD, (uint32_t)Applications::MainVFO);
             } else if (keyCode == Keyboard::KeyCode::KEY_MENU) {
                 inputSelect = 0; // reset direct input

--- a/src/apps/set_radio.h
+++ b/src/apps/set_radio.h
@@ -30,7 +30,6 @@ namespace Applications
         SelectionListPopup optionlist; // Popup for selecting option values
 
         Settings& settings;            // Reference to global settings
-        Settings::SETTINGS initialSettings; // Original settings snapshot
 
         uint8_t inputSelect = 0;       // Accumulates digits for direct menu selection
         uint8_t optionSelected = 0;    // Currently active option index (0 when none)

--- a/src/apps/set_vfo.h
+++ b/src/apps/set_vfo.h
@@ -29,7 +29,6 @@ namespace Applications
         RadioNS::Radio& radio;
 
         Settings::VFO vfo;
-        Settings::VFO initialVFO; // store original VFO settings for change detection
 
         uint8_t inputSelect = 0;
         uint8_t optionSelected = 0;


### PR DESCRIPTION
## Summary
- centralize pending-settings check inside `Settings`
- add helper `scheduleSaveIfNeeded` to trigger saving when data changed
- remove change checks from `MainVFO`, `SetRadio`, and `SetVFO`

## Testing
- `make` *(fails: `/bin/sh: 1: Syntax error: end of file unexpected (expecting "then")`)*

------
https://chatgpt.com/codex/tasks/task_e_6845918a92dc8332a846c1993dab5c33