### PR TITLE
Implement EEPROM initialization with progress display

### DIFF
--- a/src/apps/reset_init.cpp
+++ b/src/apps/reset_init.cpp
@@ -21,10 +21,13 @@ void ResetInit::drawScreen(void) {
     if (isToInitialize) {
         ui.drawString(TextAlign::CENTER, 0, 128, 8, true, false, false, "EEPROM INITIALIZATION");
         // show progress bar and percentage
-        u8g2_uint_t barWidth = (u8g2_uint_t)((initProgress * 120) / 100); // Calculate the width of the progress bar
+        u8g2_uint_t barWidth = (u8g2_uint_t)((initProgress * 120) / 100);
         ui.lcd()->drawFrame(4, 20, 120, 10);
-        ui.lcd()->drawBox(4, 20, barWidth, 10); // Draw the progress bar
+        ui.lcd()->drawBox(4, 20, barWidth, 10);
         ui.drawStringf(TextAlign::CENTER, 0, 128, 46, true, false, false, "%d%%", initProgress);
+        if (isReady) {
+            ui.drawString(TextAlign::CENTER, 0, 128, 36, true, false, false, "DONE");
+        }
     }
     else {
 

--- a/src/system/settings.h
+++ b/src/system/settings.h
@@ -290,11 +290,22 @@ public:
     }
 
     uint8_t initEEPROM(void) {
-        // TODO: Implement EEPROM initialization
+        static constexpr uint16_t blockSize = 0x0200; // 512 bytes per block
+        uint8_t buffer[blockSize];
+
         if (initBlock < maxBlock) {
+            memset(buffer, 0xFF, sizeof(buffer));
+
+            if (initBlock == 0) {
+                setRadioSettingsDefault();
+                memcpy(buffer, &radioSettings, sizeof(SETTINGS));
+            }
+
+            eeprom.writeBuffer(initBlock * blockSize, buffer, sizeof(buffer));
             initBlock++;
         }
-        return (uint8_t)((initBlock * 100) / maxBlock);
+
+        return static_cast<uint8_t>((initBlock * 100) / maxBlock);
     }
 
     void saveRadioSettings() {


### PR DESCRIPTION
## Summary
- add EEPROM initialization logic in `Settings::initEEPROM`
- show initialization completion on progress screen

## Testing
- `make -n`
- `make -j4` *(fails: arm-none-eabi-g++ not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459907cbc08332b07da54b0accec53